### PR TITLE
Allow using hex colors for styles

### DIFF
--- a/actions/AJh-8556g/server.js
+++ b/actions/AJh-8556g/server.js
@@ -22,9 +22,11 @@ function(properties, context) {
         
         return '#' + convertedColor.join('');
     }
+
+    const hexColor = color.startsWith("#") ? color : convertRGBAtoHEX(color);
     
     configs.docDefinition.styles[style_name] = { 
-        color: convertRGBAtoHEX(color), 
+        color: hexColor, 
         fontSize, 
         bold, 
         italics, 


### PR DESCRIPTION
Currently, only RGBA values are accepted in styles (e.g. `rgba(1,22,123)`). When using the PDF Conjurer together with a color picker plugin, using HEX colors directly would be a nice option.

This PR does exactly that: it will accept HEX colors starting with `#` and only convert RGBA to HEX if needed.

Btw: thanks for this awesome plugin 😊